### PR TITLE
Fix for last modified column not existing on a new model and custom headers

### DIFF
--- a/sqlrest.js
+++ b/sqlrest.js
@@ -210,18 +210,17 @@ function Sync(method, model, opts) {
 		}
 	}
 
-	//send last modified model datestamp to the remote server
-	var lastModifiedValue = "";
-	try {
-		lastModifiedValue = sqlLastModifiedItem();		
-	}
-	catch(e) {
-		if(DEBUG){ 
-			Ti.API.debug("[SQL REST API] LASTMOD SQL FAILED: ");
-			} 
-	}
-
 	if(lastModifiedColumn && _.isUndefined(params.disableLastModified)){
+		//send last modified model datestamp to the remote server
+		var lastModifiedValue = "";
+		try {
+			lastModifiedValue = sqlLastModifiedItem();		
+		}
+		catch(e) {
+			if(DEBUG){ 
+				Ti.API.debug("[SQL REST API] LASTMOD SQL FAILED: ");
+			} 
+		}
 		params.headers['Last-Modified'] = lastModifiedValue;
 	}
 	


### PR DESCRIPTION
These two pull requests have a fix and a feature.
1) fix the SQL error caused by last modified column not existing on a new model
2) Allow user to specify a set of custom headers. This allows things like StackMob API keys to be passed. E.g.

```
        "headers": {
            "Accept": "application/vnd.stackmob+json; version=0",
        "X-StackMob-API-Key": "your-stackmob-key"
        },
```
