### PR TITLE
Logger helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ collection.fetch({
 
 ## Changelog
 
+**v0.1.40**  
+Moved the DEBUG calls to a Logger Helper following the same approach as the RestAPI Adapter.
+
 **v0.1.39**  
 Added support for HTTP response code 201, 204 as success.  
 `deleteAllOnFetch` now also work on fetch params. 

--- a/sqlrest.js
+++ b/sqlrest.js
@@ -1,7 +1,7 @@
 /**
  * SQL Rest Adapter for Titanium Alloy
  * @author Mads Møller
- * @version 0.1.39
+ * @version 0.1.40
  * Copyright Napp ApS
  * www.napp.dk
  */
@@ -296,7 +296,7 @@ function Sync(method, model, opts) {
 	//json data transfers
 	params.headers['Content-Type'] = 'application/json';
 
-	logger(DEBUG, "REST METHOD: ", method);
+	logger(DEBUG, "REST METHOD: " + method);
 
 	switch (method) {
 		case 'create':


### PR DESCRIPTION
moved all DEBUG calls to use a Logger Helper function just like it happens on RESTAPI adapter.
