### PR TITLE
avoid invalid sql statement when where is empty

### DIFF
--- a/sqlrest.js
+++ b/sqlrest.js
@@ -830,7 +830,7 @@ function _buildQuery(table, opts) {
 
 	sql += ' FROM ' + table;
 
-	if (opts.where) {
+	if (opts.where && !_.isEmpty(opts.where)) {
 		var where;
 		if (_.isArray(opts.where)) {
 			where = opts.where.join(' AND ');


### PR DESCRIPTION
I was dynamically creating an object to set the where option. If `opts` is an empty object it throws an "invalid SQL statement" error. This additional check transfers `where: {}` to `where 1=1`

``` javascript
collection.fetch({
    sql: {  
        where: opts
    },
    localOnly: true
});
```
