### PR TITLE
Results are empty if localOnly is anything but undefined on 'read' requests

### DIFF
--- a/sqlrest.js
+++ b/sqlrest.js
@@ -389,7 +389,7 @@ function Sync(method, model, opts) {
 					}
 
 					var data = parseJSON(_response, parentNode);
-					if (_.isUndefined(params.localOnly)) {
+					if (!params.localOnly) {
 						//we dont want to manipulate the data on localOnly requests
 						saveData(data);
 					}


### PR DESCRIPTION
The issue is from this line of code here:

https://github.com/viezel/napp.alloy.adapter.restsql/blob/master/sqlrest.js#L392

Basically, in my case I was calling fetch like this: `collection.fetch({ localOnly: false });` which then resulted in the above line of code to evaluate to false because false !== undefined, thus not saving the data into the sqlite db.

Because of that, and because results are retrieved from the sqlite db after a remote fetch, the results in the database were empty.
