### PR TITLE
Headers property as function and success method

### DIFF
--- a/sqlrest.js
+++ b/sqlrest.js
@@ -349,9 +349,10 @@ function Sync(method, model, opts) {
         }
     }
 
-    // Extend the provided url params with those from the model config
-    if (_.isObject(params.urlparams) || model.config.URLPARAMS) {
-        _.extend(params.urlparams, _.isFunction(model.config.URLPARAMS) ? model.config.URLPARAMS() : model.config.URLPARAMS);
+    // Extend the provided url params with those from the model config    
+    if (model.config.URLPARAMS) {
+        _.isUndefined(params.urlparams) && (params.urlparams={});    
+        _.extend(params.urlparams, (_.isFunction(model.config.URLPARAMS) ? model.config.URLPARAMS() : model.config.URLPARAMS));        
     }
 
     // For older servers, emulate JSON by encoding the request into an HTML-form.


### PR DESCRIPTION
1. Success method must provide «success» and «xhr» arguments for
backbone model and collection method «parse». You can inspect backbone «fetch» method for example.

2. Headers property of model config now can be function. Use this for variable set headers.