### PR TITLE
Introduce appc-npm support for better dependency management

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.git
+.project
+README.md
+test

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Grab the latest version from the [repo](https://raw.githubusercontent.com/viezel
 This library can also be installed as NPM dependency. Add it by running in the root of your `PROJECT_FOLDER`.
 
 ```
-npm install alloy-sync-restsql --save-dev
+npm install alloy-sync-restsql --save
 ```
 This will install the library in `PROJECT_FOLDER/app/vendor/alloy/sync`. Vendor is being used so you'll be able to ignore this dependency from version control.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ The adapter has been desinged with the following structure.
 * **404:** The resource was not found.
 * **500:** A server error occurred.
 
+## Installation
+
+### Manual
+
+Grab the latest version from the [repo](https://raw.githubusercontent.com/viezel/napp.alloy.adapter.restsql/master/sqlrest.js) and save the file to `PROJECT_FOLDER/app/alloy/sync`
+
+### Appc NPM
+
+This library can also be installed as NPM dependency. Add it by running in the root of your `PROJECT_FOLDER`.
+
+```
+npm install alloy-sync-restsql --save-dev
+```
+This will install the library in `PROJECT_FOLDER/app/vendor/alloy/sync`. Vendor is being used so you'll be able to ignore this dependency from version control.
+
 ## How To Use
 
 Simple add the following to your model in `PROJECT_FOLDER/app/models/`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The adapter has been desinged with the following structure.
 
 ### Manual
 
-Grab the latest version from the [repo](https://raw.githubusercontent.com/viezel/napp.alloy.adapter.restsql/master/sqlrest.js) and save the file to `PROJECT_FOLDER/app/alloy/sync`
+Grab the latest version from the [repo](https://raw.githubusercontent.com/viezel/napp.alloy.adapter.restsql/master/sqlrest.js) and save the file to `PROJECT_FOLDER/app/lib/alloy/sync`
 
 ### Appc NPM
 

--- a/appc-npm
+++ b/appc-npm
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+
+var path = require('path');
+var fs = require('fs');
+var child_process = require('child_process');
+
+var OS_WINDOWS = (process.platform === 'win32');
+
+install();
+
+function install() {
+  var pkg;
+
+  try {
+    pkg = JSON.parse(fs.readFileSync('package.json', {
+      encoding: 'utf-8'
+    }));
+  } catch (e) {
+    die('Could not read package.json');
+  }
+
+  var appcNPM = pkg['appc-npm'];
+
+  if (typeof appcNPM !== 'object') {
+    die('Could not find \'appc-npm\' in package.json');
+  }
+
+  var target = findTarget();
+
+  if (!target) {
+    die('Could not find project');
+  }
+
+  var targetPath = (typeof appcNPM.target === 'object') ? appcNPM.target[target.name] : appcNPM.target;
+
+  if (typeof targetPath !== 'string') {
+    die('Could not find \'appc-npm.target.' + target.name + '\' or \'appc-npm.target\' in package.json');
+  }
+
+  targetPath = path.join(target.base, targetPath);
+
+  var zipFiles = toArray(appcNPM.unzip);
+
+  // unzip
+  if (zipFiles.length > 0) {
+
+    if (OS_WINDOWS) {
+      mkdirsSync(targetPath);
+    }
+
+    unzip(zipFiles, targetPath, configure);
+
+    // copy
+  } else {
+    var ignore = toArray(appcNPM.ignore);
+    ignore.push('appc-npm', '.gitignore', '.npmignore');
+
+    try {
+      copySync(__dirname, targetPath, function (fullPath) {
+        var relPath = fullPath.substr(__dirname.length + 1);
+
+        return ignore.indexOf(relPath) === -1;
+      });
+
+    } catch (e) {
+      die('Could not copy \'' + __dirname + '\' to \'' + targetPath + '\'');
+    }
+
+    console.log('Copied \'' + __dirname + '\' to \'' + targetPath + '\'');
+
+    configure();
+  }
+
+  // configure tiapp.xml and config.json
+  function configure() {
+
+    // config.json
+    if (appcNPM.config) {
+      var configPath = path.join(target.base, 'app', 'config.json');
+      var config;
+
+      try {
+        config = require(configPath);
+      } catch (e) {
+        config = {};
+      }
+
+      if (!config.dependencies) {
+        config.dependencies = {};
+      }
+
+      for (var id in appcNPM.config) {
+        if (config.dependencies[id] !== appcNPM.config[id]) {
+          config.dependencies[id] = appcNPM.config[id];
+        }
+      }
+
+      try {
+        fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+        console.log('Updated app/config.json');
+
+      } catch (e) {
+        die('Could not write updated app/config.json');
+      }
+    }
+
+    // tiapp.xml
+    if (appcNPM.tiapp) {
+      var tiappPath = path.join(target.base, 'tiapp.xml');
+      var tiapp;
+
+      try {
+        tiapp = fs.readFileSync(tiappPath, {
+          encoding: 'utf-8'
+        });
+      } catch (e) {
+        die('Could not read tiapp.xml' + e + ' ' + tiappPath);
+      }
+
+      var add = [];
+
+      appcNPM.tiapp.forEach(function(mod) {
+        var xml = '<module platform="' + mod.platform + '" version="' + mod.version + '">' + mod.name + '</module>';
+
+        var reModule = new RegExp('<module[^>]+>' + mod.name + '</module>');
+
+        // update existing
+        if (reModule.test(tiapp)) {
+          tiapp = tiapp.replace(reModule, xml);
+
+          // queue to be added
+        } else {
+          add.push(xml);
+        }
+      });
+
+      if (add.length > 0) {
+        var reModules = /(\n)?(\s*<\/modules>)/;
+        var reModulesClosed = /<modules\s*\/>/;
+        var reTiapp = /(\n)?(\s*<\/ti:app>)/;
+
+        var xml = '\t\t' + add.join('\n\t\t') + '\n';
+        var modulesXml = '<modules>\n' + xml + '\t</modules>';
+
+        // has <modules>..</modules>
+        if (reModules.test(tiapp)) {
+          tiapp = tiapp.replace(reModules, '$1' + xml + '$2');
+
+          // has <modules/>
+        } else if (reModulesClosed.test(tiapp)) {
+          tiapp = tiapp.replace(reModulesClosed, modulesXml);
+
+          // insert before </ti:app>
+        } else if (reTiapp.test(tiapp)) {
+          tiapp = tiapp.replace(reTiapp, '$1\t' + modulesXml + '\n$2');
+
+          // invalid tiapp.xml
+        } else {
+          die('Could not update tiapp.xml');
+        }
+      }
+
+      try {
+        fs.writeFileSync(tiappPath, tiapp);
+
+        console.log('Updated tiapp.xml');
+
+      } catch (e) {
+        die('Could not write updated tiapp.xml');
+      }
+    }
+
+    console.log();
+    process.exit(0);
+  }
+}
+
+function unzip(files, targetPath, next) {
+  var file = files.shift();
+  var filePath = path.join(__dirname, file);
+  var command;
+
+  if (OS_WINDOWS) {
+    command = '/c cd "' + targetPath + '" && jar xf "' + filePath + '"';
+
+  } else {
+    command = 'unzip -o "' + filePath + '" -d "' + targetPath + '"';
+  }
+
+  return child_process.exec(command, function(error, stdout, stderr) {
+
+    if (error) {
+
+      var err = 'Could not unzip \'' + filePath + '\': ' + stderr;
+
+      if (OS_WINDOWS) {
+        var EOL = require('os').EOL;
+        err += EOL + 'Make sure you have Java JDK installed and added to PATH: ' + EOL + 'http://docs.oracle.com/javase/8/docs/technotes/guides/install/windows_jdk_install.html#BABGDJFH';
+      }
+
+      die(err);
+
+    } else {
+      console.log('Unzipped ' + file);
+
+      if (files.length > 0) {
+        unzip(files, targetPath, next);
+
+      } else {
+        next();
+      }
+    }
+  });
+}
+
+function findTarget(dir) {
+
+  if (dir) {
+
+    if (fs.existsSync(path.join(dir, 'appc.json'))) {
+      return {
+        name: 'arrow',
+        base: dir
+      };
+    } else if (fs.existsSync(path.join(dir, 'app', 'controllers', 'index.js'))) {
+      return {
+        name: 'alloy',
+        base: dir
+      };
+    } else if (fs.existsSync(path.join(dir, 'tiapp.xml'))) {
+      return {
+        name: 'titanium',
+        base: dir
+      };
+    }
+
+  } else {
+    dir = __dirname;
+  }
+
+  dirUp = path.resolve(dir, '..', '..');
+
+  if (!dirUp || dirUp === dir) {
+    return;
+  }
+
+  return findTarget(dirUp);
+}
+
+function die(err) {
+  console.error(err);
+  console.error();
+  process.exit(1);
+}
+
+function toArray(val) {
+
+  if (typeof val === 'string') {
+    return [val];
+  } else if (Object.prototype.toString.call(val) === '[object Array]') {
+    return val;
+  } else {
+    return [];
+  }
+
+}
+
+/* jshint ignore:start */
+
+// https://github.com/jprichardson/node-fs-extra/blob/master/lib/copy/copy-sync.js
+function copySync (src, dest, options) {
+  if (typeof options === 'function' || options instanceof RegExp) {
+    options = {filter: options}
+  }
+
+  options = options || {}
+  options.recursive = !!options.recursive
+
+  // default to true for now
+  options.clobber = 'clobber' in options ? !!options.clobber : true
+
+  options.filter = options.filter || function () { return true }
+
+  var stats = options.recursive ? fs.lstatSync(src) : fs.statSync(src)
+  var destFolder = path.dirname(dest)
+  var destFolderExists = fs.existsSync(destFolder)
+  var performCopy = false
+
+  if (stats.isFile()) {
+    if (options.filter instanceof RegExp) performCopy = options.filter.test(src)
+    else if (typeof options.filter === 'function') performCopy = options.filter(src)
+
+    if (performCopy) {
+      if (!destFolderExists) mkdirsSync(destFolder)
+      copyFileSync(src, dest, options.clobber)
+    }
+  } else if (stats.isDirectory()) {
+    if (!fs.existsSync(dest)) mkdirsSync(dest)
+    var contents = fs.readdirSync(src)
+    contents.forEach(function (content) {
+      copySync(path.join(src, content), path.join(dest, content), {filter: options.filter, recursive: true})
+    })
+  } else if (options.recursive && stats.isSymbolicLink()) {
+    var srcPath = fs.readlinkSync(src)
+    fs.symlinkSync(srcPath, dest)
+  }
+}
+
+// https://github.com/jprichardson/node-fs-extra/blob/master/lib/copy/copy-file-sync.js
+function copyFileSync (srcFile, destFile, clobber) {
+
+  if (fs.existsSync(destFile) && !clobber) {
+    throw Error('EXIST')
+  }
+
+  // simplified to work with vanilla fs
+  fs.writeFileSync(destFile, fs.readFileSync(srcFile));
+}
+
+// https://github.com/jprichardson/node-fs-extra/blob/master/lib/mkdirs/mkdirs.js
+var o777 = parseInt('0777', 8)
+
+function mkdirsSync (p, opts, made) {
+  if (!opts || typeof opts !== 'object') {
+    opts = { mode: opts }
+  }
+
+  var mode = opts.mode
+  var xfs = opts.fs || fs
+
+  if (mode === undefined) {
+    mode = o777 & (~process.umask())
+  }
+  if (!made) made = null
+
+  p = path.resolve(p)
+
+  try {
+    xfs.mkdirSync(p)//, mode)   <!-- failed
+    made = made || p
+  } catch (err0) {
+    switch (err0.code) {
+      case 'ENOENT' :
+        made = mkdirsSync(path.dirname(p), opts, made)
+        mkdirsSync(p, opts, made)
+        break
+
+      // In the case of any other error, just see if there's a dir
+      // there already.  If so, then hooray!  If not, then something
+      // is borked.
+      default:
+        var stat
+        try {
+          stat = xfs.statSync(p)
+        } catch (err1) {
+          throw err0
+        }
+        if (!stat.isDirectory()) throw err0
+        break
+    }
+  }
+
+  return made
+}
+
+/* jshint ignore:end */

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "alloy-sync-sqlrest",
+  "version": "0.3.2",
+  "description": "SQL & RestAPI Sync Adapter for Titanium Alloy",
+  "author": {
+    "name": "Mads Møller",
+    "email": "mm@napp.dk"
+  },
+  "homepage": "https://github.com/viezel/napp.alloy.adapter.restsql",
+  "bugs": {
+    "url": "https://github.com/viezel/napp.alloy.adapter.restsql/issues"
+  },
+  "appc-npm": {
+    "target": {
+      "alloy": "app/vendor/alloy/sync/"
+    },
+    "ignore": [
+      ".git",
+      ".project",
+      "README.md",
+      "package.json",
+      "test"
+    ]
+  },
+  "scripts": {
+    "postinstall": "node ./appc-npm"
+  },
+  "keywords": [
+    "alloy",
+    "alloy-sync",
+    "appc-npm",
+    "appcelerator",
+    "crud",
+    "napp",
+    "rest",
+    "sqlite",
+    "titanium"
+  ]
+}


### PR DESCRIPTION
Hey Mads,

I saw that @FokkeZB added support to the RestAPI adapter. Here's the support for the restsql version.
Could you publish this using the latest version of appc-npm if you are OK with the additions?

It does not install to the default `lib` directory, but `vendor` to be able to treat it as proper 3rd party dependency.