### PR TITLE
Pass fetch options to parentNode function

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ http://www.google.com/calendar/feeds/developer-calendar@google.com/public/full?a
 *Custom parsing:*
 			
 ```javascript
-parentNode: function (data) {
+parentNode: function (data, options) {
 	// check if its a collection
 	if (_.isArray(data)) {	
 		var entries = [];
@@ -165,6 +165,7 @@ parentNode: function (data) {
 			entry.endTime = _entry.gd$when[0].endTime;
 			entry.title = _entry.title.$t;
 			entry.content = _entry.content.$t;
+			entry.myCustomPropertyFromFetchOpts = options.query
 	
 			entries.push(entry);
 		});
@@ -357,6 +358,9 @@ function infiniteCallback(e) {
 ```
 
 ## Changelog
+
+**v0.3.5** 
+Pass fetch options paramter to `parentNode` function
 
 **v0.3.4** 
 Using defer(underscore.js) at saveData() for prevent block event, and transaction more efficient. Keeping App Responsive.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alloy-sync-sqlrest",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "SQL & RestAPI Sync Adapter for Titanium Alloy",
   "author": {
     "name": "Mads Møller",

--- a/sqlrest.js
+++ b/sqlrest.js
@@ -1026,7 +1026,7 @@ function Sync(method, model, opts) {
 	function parseJSON(_response, parentNode) {
 		var data = _response.responseJSON;
 		if (!_.isUndefined(parentNode)) {
-			data = _.isFunction(parentNode) ? parentNode(data) : traverseProperties(data, parentNode);
+			data = _.isFunction(parentNode) ? parentNode(data, opts) : traverseProperties(data, parentNode);
 		}
 		logger(DEBUG, "server response: ", data);
 		return data;


### PR DESCRIPTION
Hi,

Most of time i need some parameters like parentCategoryID while i'm parsing response from rest service, this pull request let us access the fetch options including `sql` and `requestparams` while parsing the response.

Example
```javascript
 parentNode: function(data, opts) {
      return _.map(data, function(value) {
        // Insert images
        return {
          id: value.id,
          product_id: opts.requestparams.product_id,
          url: value.url
        };
      });
    }
```