### PR TITLE
Fixes a bug where data item is undefined

### DIFF
--- a/sqlrest.js
+++ b/sqlrest.js
@@ -654,7 +654,11 @@ function Sync(method, model, opts) {
 			function iteration(data, i, queryList) {
 				i || (i = 0);
 				queryList = queryList || [];
-
+				
+				if (_.isUndefined(data[i])){
+					return;
+				}
+				
 				if (!_.isUndefined(data[i][model.deletedAttribute]) && data[i][model.deletedAttribute] == true) {
 					//delete item
 					queryList = deleteSQL(data[i][model.idAttribute], queryList);


### PR DESCRIPTION
This error is not really reproducable. I sometimes got this on the first start.

```
[ERROR] Script Error {
[ERROR]     column = 46;
[ERROR]     line = 181;
[ERROR]     message = "undefined is not an object (evaluating 'data[i][model.deletedAttribute]')";
[ERROR]     sourceURL = "file:///Users/manu/Library/Developer/CoreSimulator/Devices/7049E447-48FF-4944-B64F-5505F63FE573/data/Containers/Bundle/Application/7F7C20DE-CC43-45E2-80D3-9E59EEF2B5FE/Finde%20dein%20Erlebnis.app/alloy/sync/sqlrest.js";
[ERROR]     stack = "iteration@file:///Users/manu/Library/Developer/CoreSimulator/Devices/7049E447-48FF-4944-B64F-5505F63FE573/data/Containers/Bundle/Application/7F7C20DE-CC43-45E2-80D3-9E59EEF2B5FE/Finde%20dein%20Erlebnis.app/alloy/sync/sqlrest.js:181:46\nfile:///Users/manu/Library/Developer/CoreSimulator/Devices/7049E447-48FF-4944-B64F-5505F63FE573/data/Containers/Bundle/Application/7F7C20DE-CC43-45E2-80D3-9E59EEF2B5FE/Finde%20dein%20Erlebnis.app/alloy/underscore.js:666:52";
[ERROR] }
```

Maybe it tries to access the local database before it has finished initializing itself. Not sure. But this catch should fix it.