### PR TITLE
Fixes a bug where local SQL data was not created after successful ser…

### DIFF
--- a/sqlrest.js
+++ b/sqlrest.js
@@ -652,7 +652,7 @@ function Sync(method, model, opts) {
 			}
 
 			function iteration(data, i, queryList) {
-				i || (i = 0);
+				i = _.isNumber(i) ? i : 0;
 				queryList = queryList || [];
 				
 				if (_.isUndefined(data[i])){
@@ -757,7 +757,7 @@ function Sync(method, model, opts) {
 		// Assemble create query
 		var sqlInsert = "INSERT INTO " + table + " (" + names.join(",") + ") VALUES (" + q.join(",") + ");";
 
-		if (queryList) {
+		if (!_.isUndefined(queryList) && _.isFunction(queryList.push)) {
 			queryList.push({
 				"sql" : sqlInsert,
 				"values" : values


### PR DESCRIPTION
…ver response

This bug sometimes appeared on `collection.fetch` with  `opts.deleteAllOnFetch`.

The server answered correctly but it didn't update the local database. I think this only happens when the queryList is used. If it inserts directly, all is fine. 

When I was debugging this I found that the iteration function gets an Array of arguments passed (the data itself) where `i` should be passed. That happens on the first iteration call, where i should be set to null but _.defer doesn't pass nothing (undefined) as second parameter but these arguments.